### PR TITLE
fix view configuration deprecated value

### DIFF
--- a/lib/src/capturer.dart
+++ b/lib/src/capturer.dart
@@ -285,7 +285,9 @@ class RenderCapturer<K extends RenderFormat> {
         child: RenderPositionedBox(
             alignment: Alignment.center, child: repaintBoundary),
         configuration: ViewConfiguration(
-          size: logicalSize,
+          physicalConstraints:
+              BoxConstraints.tight(logicalSize) * flutterView.devicePixelRatio,
+          logicalConstraints: BoxConstraints.tight(logicalSize),
           devicePixelRatio: session.settings.pixelRatio,
         ),
       );


### PR DESCRIPTION
According to documentation in new Flutter version, ViewConfiguration class no taking **size** param anymore. It takes **physicalConstraints** and **logicalConstraints** params. So, I found a way to handle it and created a PR. Please review and merge it. Feel free to give feedback if needed.